### PR TITLE
Add option for persistant notice

### DIFF
--- a/src/Notices.php
+++ b/src/Notices.php
@@ -127,7 +127,9 @@ class Notices {
 
 		foreach ( $notices as $notice ) {
 			if ( $notice->show() ) {
-				$notice->dismiss->print_script();
+				if( $notice->is_dismissible() ) {
+					$notice->dismiss->print_script();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For my own purpose, I need some persistant Notice, not dismissable. 
For example : when my theme need another plugin to be activated... the notice should be displayed on admin screen until this plugin activation...