### PR TITLE
Add 3 tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 /composer.json        export-ignore
 /composer.lock        export-ignore
 /contributing.md      export-ignore
+/phpstan.neon.dist    export-ignore
 
 # Handle line endings.
 # See https://help.github.com/articles/dealing-with-line-endings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-composer.lock
-/vendor
+/composer.lock
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,21 @@
 	},
 	"require"     : {
 		"php" : ">=5.6"
+	},
+	"require-dev": {
+		"php" : "~7.1",
+		"wp-coding-standards/wpcs": "^2.3",
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",
+		"szepeviktor/phpstan-wordpress": "^0.6.0"
+	},
+	"scripts": {
+		"ci:syntax": "find src/ -type f -name '*.php' -print0|xargs -0 -L 1 -- php -l",
+		"ci:coding-standars": "phpcs --standard=WordPress-Core --exclude=Generic.Arrays.DisallowShortArraySyntax src/",
+		"ci:static-analysis": "phpstan analyze",
+		"test": [
+			"@ci:syntax",
+			"@ci:coding-standars",
+			"@ci:static-analysis"
+		]
 	}
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,9 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+parameters:
+    level: max
+    inferPrivatePropertyTypeFromConstructor: true
+    # TODO Add array types
+    checkMissingIterableValueType: false
+    paths:
+        - src/

--- a/src/Dismiss.php
+++ b/src/Dismiss.php
@@ -52,7 +52,7 @@ class Dismiss {
 	 * @since 1.0
 	 * @param string $id     A unique ID for this notice. Can contain lowercase characters and underscores.
 	 * @param string $prefix The prefix that will be used for the option/user-meta.
-	 * @param string $scope
+	 * @param string $scope  Controls where the dismissal will be saved: user or global.
 	 */
 	public function __construct( $id, $prefix, $scope = 'global' ) {
 

--- a/src/Dismiss.php
+++ b/src/Dismiss.php
@@ -52,6 +52,7 @@ class Dismiss {
 	 * @since 1.0
 	 * @param string $id     A unique ID for this notice. Can contain lowercase characters and underscores.
 	 * @param string $prefix The prefix that will be used for the option/user-meta.
+	 * @param string $scope
 	 */
 	public function __construct( $id, $prefix, $scope = 'global' ) {
 

--- a/src/Notice.php
+++ b/src/Notice.php
@@ -289,7 +289,9 @@ class Notice {
 			require_once ABSPATH . 'wp-admin/includes/screen.php';
 		}
 
+		/** @var \WP_Screen $current_screen */
+		$current_screen = get_current_screen();
 		// Check if we're on one of the defined screens.
-		return ( in_array( get_current_screen()->id, $this->options['screens'], true ) );
+		return ( in_array( $current_screen->id, $this->options['screens'], true ) );
 	}
 }

--- a/src/Notice.php
+++ b/src/Notice.php
@@ -84,8 +84,8 @@ class Notice {
 	private $allowed_html = [
 		'p'      => [],
 		'a'      => [
-			'href'  => [],
-			'rel'   => [],
+			'href' => [],
+			'rel'  => [],
 		],
 		'em'     => [],
 		'strong' => [],
@@ -103,7 +103,7 @@ class Notice {
 		'info',
 		'success',
 		'error',
-		'warning'
+		'warning',
 	];
 
 	/**
@@ -135,10 +135,10 @@ class Notice {
 	public function __construct( $id, $title, $message, $options = [] ) {
 
 		// Set the object properties.
-		$this->id         = $id;
-		$this->title      = $title;
-		$this->message    = $message;
-		$this->options    = wp_parse_args( $options, $this->options );
+		$this->id      = $id;
+		$this->title   = $title;
+		$this->message = $message;
+		$this->options = wp_parse_args( $options, $this->options );
 
 		// Sanity check: Early exit if ID or message are empty.
 		if ( ! $this->id || ! $this->message ) {
@@ -225,7 +225,7 @@ class Notice {
 		];
 
 		// Make sure the defined type is allowed.
-		$this->options['type'] = in_array( $this->options['type'], $this->allowed_types ) ? $this->options['type'] : 'info';
+		$this->options['type'] = in_array( $this->options['type'], $this->allowed_types, true ) ? $this->options['type'] : 'info';
 
 		// Add the class for notice-type.
 		$classes[] = 'notice-' . $this->options['type'];


### PR DESCRIPTION
```
$ composer test

> find src/ -type f -name '*.php' -print0|xargs -0 -L 1 -- php -l
No syntax errors detected in src/Dismiss.php
No syntax errors detected in src/Notice.php
No syntax errors detected in src/Notices.php
> phpcs --standard=WordPress-Core --exclude=Generic.Arrays.DisallowShortArraySyntax src/
> phpstan analyze
Note: Using configuration file /home/viktor/src/admin-notices/phpstan.neon.dist.
 3/3 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


 [OK] No errors

```

@aristath