### PR TITLE
Fix Firefox race condition #14

### DIFF
--- a/src/Notices.php
+++ b/src/Notices.php
@@ -42,9 +42,6 @@ class Notices {
 
 		// Add the notice.
 		add_action( 'admin_notices', [ $this, 'the_notices' ] );
-
-		// Print the script to the footer.
-		add_action( 'admin_footer', [ $this, 'print_scripts' ] );
 	}
 
 	/**
@@ -113,23 +110,6 @@ class Notices {
 
 		foreach ( $notices as $notice ) {
 			$notice->the_notice();
-		}
-	}
-
-	/**
-	 * Prints scripts for the notices.
-	 *
-	 * @access public
-	 * @since 1.0
-	 * @return void
-	 */
-	public function print_scripts() {
-		$notices = $this->get_all();
-
-		foreach ( $notices as $notice ) {
-			if ( $notice->show() ) {
-				$notice->dismiss->print_script();
-			}
 		}
 	}
 }


### PR DESCRIPTION
Fix #14 . Changes:

Previously the script was printed into HTML in the `admin_footer` action.
Now it is enqueued as a `wp_add_inline_script` script, with `common` as its dependency.

`common.js` is the script which ads the X to `is-dismissable` `notice`s, so now our script is being printed immediately after it.

Additionally, `window.addEventListener( 'load', function() {` has been replaced with `jQuery( function() {` to match exactly what `common.js` is doing.

By loading the script later and using the same mechanism to being execution, we avoid the race condition.