### PR TITLE
Fix: Uncaught TypeError: dismissBtn is null

### DIFF
--- a/src/Dismiss.php
+++ b/src/Dismiss.php
@@ -84,7 +84,7 @@ class Dismiss {
 jQuery( function() {
     var dismissBtn = document.querySelector( '#wptrt-notice-$id .notice-dismiss' );
 
-    if( ! dismissBtn ) {
+    if ( ! dismissBtn ) {
     	return;
     }
 

--- a/src/Dismiss.php
+++ b/src/Dismiss.php
@@ -82,7 +82,11 @@ class Dismiss {
 
 		$script = <<<EOD
 jQuery( function() {
-    var dismissBtn  = document.querySelector( '#wptrt-notice-$id .notice-dismiss' );
+    var dismissBtn = document.querySelector( '#wptrt-notice-$id .notice-dismiss' );
+
+    if( ! dismissBtn ) {
+    	return;
+    }
 
     // Add an event listener to the dismiss button.
     dismissBtn.addEventListener( 'click', function( event ) {


### PR DESCRIPTION
I'm sometimes getting

```
Uncaught TypeError: dismissBtn is null
```

This checks the result of `document.querySelector` before adding the handler.